### PR TITLE
fix: change min node count to 4

### DIFF
--- a/website/docs/fundamentals/managed-node-groups/adding-nodes/index.md
+++ b/website/docs/fundamentals/managed-node-groups/adding-nodes/index.md
@@ -14,7 +14,7 @@ We'll scale the nodegroup in `eks-workshop` by changing the node count from `3` 
 
 ```bash
 $ eksctl scale nodegroup --name $EKS_DEFAULT_MNG_NAME --cluster $EKS_CLUSTER_NAME \
-    --nodes 4 --nodes-min 3 --nodes-max 6
+    --nodes 4 --nodes-min 4 --nodes-max 6
 ```
 
 :::tip


### PR DESCRIPTION
In the description above it was mentioned that we would like to change the minimum node count from 3 to 4. However, the command still has `--nodes-min` as 3.

#### What this PR does / why we need it:
Fix command for auto-scaling nodegroup
#### Which issue(s) this PR fixes:
While description says we are increasing the minimum node count to 4 command still has `--node-min` as `3`
Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
